### PR TITLE
Make the Go version take the same arguments as the C version

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -56,9 +56,10 @@ else
 fi
 
 if [ -x ../go/reop ] ; then
-	../go/reop mysec yourpub warn.txt | ../reop -D -s yoursec -p mypub -x - -m - > danger.txt
+	../go/reop -E -s mysec -p yourpub -m warn.txt -x warn.txt.enc
+	../reop -D -s yoursec -p mypub -x warn.txt.enc -m danger.txt
 	diff -u danger.txt warn.txt
-	../go/reop gorilla  warn.txt > warn.txt.enc
+	env REOP_PASSPHRASE=gorilla ../go/reop -E -m warn.txt -x warn.txt.enc
 	env REOP_PASSPHRASE=gorilla ../reop -D -x warn.txt.enc -m danger.txt
 	diff -u danger.txt warn.txt
 	echo Go passed.


### PR DESCRIPTION
I'm not sure entirely what your vision is for `go/` and `lua/`, if they're supposed to track with features in `reop.c` or just allow you to play around with concepts, but I put in some work and made the Go version take the same parameters as the C version.  Most commands don't exist yet, but everything that fails does so very, very loudly.

This version passes the Go-specific tests, which I modified slightly so that they will expect the proper interface.